### PR TITLE
Claude/outbox interceptor telemetry 011 c uc3 a9b f ragq9 g tb yq2pj

### DIFF
--- a/event-exposed/TELEMETRY.md
+++ b/event-exposed/TELEMETRY.md
@@ -1,0 +1,201 @@
+# Telemetry Integration for OutboxInterceptor
+
+## Обзор
+
+Начиная с этой версии, `OutboxInterceptor` поддерживает сохранение контекста телеметрии (trace ID и span ID) при сохранении событий. Это позволяет отслеживать события через распределенную систему и связывать их с оригинальными запросами.
+
+## Архитектура
+
+Решение состоит из следующих компонентов:
+
+### 1. TelemetryContext
+Data class, содержащий trace ID и span ID:
+```kotlin
+data class TelemetryContext(
+    val traceId: String?,
+    val spanId: String?
+)
+```
+
+### 2. TelemetryContextProvider
+Интерфейс для извлечения текущего контекста телеметрии:
+```kotlin
+interface TelemetryContextProvider {
+    fun getCurrentContext(): TelemetryContext
+}
+```
+
+### 3. TelemetryContextHolder
+Глобальный holder для провайдера телеметрии:
+```kotlin
+object TelemetryContextHolder {
+    var provider: TelemetryContextProvider = NoOpTelemetryContextProvider
+}
+```
+
+### 4. База данных
+Таблица `outbox_events` теперь содержит два дополнительных поля:
+- `trace_id` (text, nullable) - ID трейса для распределенной трассировки
+- `span_id` (text, nullable) - ID спана текущей операции
+
+## Использование
+
+### Без телеметрии (по умолчанию)
+По умолчанию используется `NoOpTelemetryContextProvider`, который возвращает пустой контекст. В этом случае `trace_id` и `span_id` будут null.
+
+### С OpenTelemetry
+
+1. Добавьте зависимость OpenTelemetry:
+```kotlin
+implementation("io.opentelemetry:opentelemetry-api:1.32.0")
+```
+
+2. Создайте провайдер:
+```kotlin
+import io.opentelemetry.api.trace.Span
+
+class OpenTelemetryContextProvider : TelemetryContextProvider {
+    override fun getCurrentContext(): TelemetryContext {
+        val span = Span.current()
+        val spanContext = span.spanContext
+
+        return if (spanContext.isValid) {
+            TelemetryContext(
+                traceId = spanContext.traceId,
+                spanId = spanContext.spanId
+            )
+        } else {
+            TelemetryContext.EMPTY
+        }
+    }
+}
+```
+
+3. Инициализируйте при старте приложения:
+```kotlin
+fun main() {
+    // Настройка OpenTelemetry...
+
+    // Установка провайдера телеметрии
+    TelemetryContextHolder.provider = OpenTelemetryContextProvider()
+
+    // Остальная инициализация приложения...
+}
+```
+
+### С Micrometer Tracing
+
+1. Добавьте зависимость Micrometer:
+```kotlin
+implementation("io.micrometer:micrometer-tracing:1.2.0")
+```
+
+2. Создайте провайдер:
+```kotlin
+import io.micrometer.tracing.Tracer
+
+class MicrometerContextProvider(private val tracer: Tracer) : TelemetryContextProvider {
+    override fun getCurrentContext(): TelemetryContext {
+        val span = tracer.currentSpan()
+        return if (span != null) {
+            TelemetryContext(
+                traceId = span.context().traceId(),
+                spanId = span.context().spanId()
+            )
+        } else {
+            TelemetryContext.EMPTY
+        }
+    }
+}
+```
+
+3. Инициализируйте с бином Tracer:
+```kotlin
+@Bean
+fun telemetryContextProvider(tracer: Tracer): TelemetryContextProvider {
+    val provider = MicrometerContextProvider(tracer)
+    TelemetryContextHolder.provider = provider
+    return provider
+}
+```
+
+## Миграция базы данных
+
+Для существующих баз данных необходимо выполнить миграцию:
+
+```sql
+ALTER TABLE outbox_events
+    ADD COLUMN IF NOT EXISTS trace_id text,
+    ADD COLUMN IF NOT EXISTS span_id text;
+```
+
+SQL-файл миграции находится в:
+`event-exposed/src/main/resources/migrations/add_telemetry_columns.sql`
+
+## Примеры использования
+
+### Пример 1: Простое сохранение события
+```kotlin
+transaction {
+    // Если телеметрия настроена, trace/span будут автоматически сохранены
+    events.addEvent(UserCreatedEvent(userId = "123"))
+}
+```
+
+### Пример 2: Восстановление контекста при публикации
+```kotlin
+class OutboxPublisher(/* ... */) {
+    private fun publishEvent(event: PublicEvent, traceId: String?, spanId: String?) {
+        // Можно восстановить контекст телеметрии при публикации
+        if (traceId != null && spanId != null) {
+            // Создать дочерний span с родительским контекстом
+            // и опубликовать событие в этом контексте
+        }
+
+        publishers.forEach { it.publish(event.original) }
+    }
+}
+```
+
+## Тестирование
+
+Пример теста с mock провайдером:
+
+```kotlin
+@Test
+fun `should save telemetry context`() {
+    TelemetryContextHolder.provider = object : TelemetryContextProvider {
+        override fun getCurrentContext() = TelemetryContext(
+            traceId = "test-trace-123",
+            spanId = "test-span-456"
+        )
+    }
+
+    try {
+        transaction {
+            events.addEvent(TestEvent())
+        }
+
+        transaction {
+            val savedEvent = EventsTable.selectAll().first()
+            assertEquals("test-trace-123", savedEvent[EventsTable.traceId])
+            assertEquals("test-span-456", savedEvent[EventsTable.spanId])
+        }
+    } finally {
+        TelemetryContextHolder.provider = NoOpTelemetryContextProvider
+    }
+}
+```
+
+## Производительность
+
+- Извлечение контекста телеметрии происходит **один раз** для всего батча событий (в функции `save()`)
+- Нет накладных расходов, если телеметрия не настроена (используется NoOpTelemetryContextProvider)
+- Поля `trace_id` и `span_id` nullable, поэтому не требуют заполнения
+
+## Совместимость
+
+- Решение полностью обратно совместимо
+- Существующий код работает без изменений
+- Телеметрия опциональна и активируется только при настройке провайдера
+- Поддерживает любую библиотеку телеметрии через интерфейс `TelemetryContextProvider`

--- a/event-exposed/src/main/kotlin/com/turbomates/event/exposed/OpenTelemetryContextProvider.kt
+++ b/event-exposed/src/main/kotlin/com/turbomates/event/exposed/OpenTelemetryContextProvider.kt
@@ -12,12 +12,16 @@ package com.turbomates.event.exposed
  *
  * 2. Uncomment the code below
  *
- * 3. Use in your transactions:
+ * 3. Set once at application startup:
  *    ```kotlin
- *    transaction {
- *        telemetryContextProvider = OpenTelemetryContextProvider()
- *        // Your code here - trace/span will be captured automatically
- *        events.addEvent(MyEvent())
+ *    fun main() {
+ *        // Set default provider once
+ *        TelemetryConfig.setDefaultProvider(OpenTelemetryContextProvider())
+ *
+ *        // Now all transactions automatically capture telemetry
+ *        transaction {
+ *            events.addEvent(MyEvent()) // trace/span captured automatically
+ *        }
  *    }
  *    ```
  *
@@ -64,13 +68,19 @@ package com.turbomates.event.exposed
  *
  * Example with Spring Boot:
  * ```kotlin
+ * @Configuration
+ * class TelemetryConfiguration {
+ *     @PostConstruct
+ *     fun setup() {
+ *         TelemetryConfig.setDefaultProvider(OpenTelemetryContextProvider())
+ *     }
+ * }
+ *
  * @Service
  * class OrderService {
- *     private val telemetryProvider = OpenTelemetryContextProvider()
- *
  *     fun createOrder(order: Order) {
+ *         // Telemetry works automatically - no setup needed!
  *         transaction {
- *             telemetryContextProvider = telemetryProvider
  *             OrderTable.insert { ... }
  *             events.addEvent(OrderCreatedEvent(order.id))
  *         }

--- a/event-exposed/src/main/kotlin/com/turbomates/event/exposed/OpenTelemetryContextProvider.kt
+++ b/event-exposed/src/main/kotlin/com/turbomates/event/exposed/OpenTelemetryContextProvider.kt
@@ -1,0 +1,60 @@
+package com.turbomates.event.exposed
+
+/**
+ * Example implementation of TelemetryContextProvider for OpenTelemetry.
+ *
+ * This file is provided as a reference implementation. To use it:
+ *
+ * 1. Add OpenTelemetry dependencies to your build.gradle.kts:
+ *    ```kotlin
+ *    implementation("io.opentelemetry:opentelemetry-api:1.32.0")
+ *    ```
+ *
+ * 2. Uncomment the code below
+ *
+ * 3. Initialize during application startup:
+ *    ```kotlin
+ *    TelemetryContextHolder.provider = OpenTelemetryContextProvider()
+ *    ```
+ *
+ * Example usage:
+ * ```kotlin
+ * import io.opentelemetry.api.trace.Span
+ * import io.opentelemetry.api.trace.SpanContext
+ *
+ * class OpenTelemetryContextProvider : TelemetryContextProvider {
+ *     override fun getCurrentContext(): TelemetryContext {
+ *         val span = Span.current()
+ *         val spanContext: SpanContext = span.spanContext
+ *
+ *         return if (spanContext.isValid) {
+ *             TelemetryContext(
+ *                 traceId = spanContext.traceId,
+ *                 spanId = spanContext.spanId
+ *             )
+ *         } else {
+ *             TelemetryContext.EMPTY
+ *         }
+ *     }
+ * }
+ * ```
+ *
+ * For Micrometer Tracing, use:
+ * ```kotlin
+ * import io.micrometer.tracing.Tracer
+ *
+ * class MicrometerContextProvider(private val tracer: Tracer) : TelemetryContextProvider {
+ *     override fun getCurrentContext(): TelemetryContext {
+ *         val span = tracer.currentSpan()
+ *         return if (span != null) {
+ *             TelemetryContext(
+ *                 traceId = span.context().traceId(),
+ *                 spanId = span.context().spanId()
+ *             )
+ *         } else {
+ *             TelemetryContext.EMPTY
+ *         }
+ *     }
+ * }
+ * ```
+ */

--- a/event-exposed/src/main/kotlin/com/turbomates/event/exposed/OpenTelemetryContextProvider.kt
+++ b/event-exposed/src/main/kotlin/com/turbomates/event/exposed/OpenTelemetryContextProvider.kt
@@ -12,14 +12,14 @@ package com.turbomates.event.exposed
  *
  * 2. Uncomment the code below
  *
- * 3. Set once at application startup:
+ * 3. Configure for your Database instance:
  *    ```kotlin
  *    fun main() {
- *        // Set default provider once
- *        TelemetryConfig.setDefaultProvider(OpenTelemetryContextProvider())
+ *        val database = Database.connect(...)
+ *        database.telemetryProvider = OpenTelemetryContextProvider()
  *
  *        // Now all transactions automatically capture telemetry
- *        transaction {
+ *        transaction(database) {
  *            events.addEvent(MyEvent()) // trace/span captured automatically
  *        }
  *    }
@@ -69,18 +69,20 @@ package com.turbomates.event.exposed
  * Example with Spring Boot:
  * ```kotlin
  * @Configuration
- * class TelemetryConfiguration {
- *     @PostConstruct
- *     fun setup() {
- *         TelemetryConfig.setDefaultProvider(OpenTelemetryContextProvider())
+ * class DatabaseConfiguration {
+ *     @Bean
+ *     fun database(): Database {
+ *         val database = Database.connect(...)
+ *         database.telemetryProvider = OpenTelemetryContextProvider()
+ *         return database
  *     }
  * }
  *
  * @Service
- * class OrderService {
+ * class OrderService(private val database: Database) {
  *     fun createOrder(order: Order) {
- *         // Telemetry works automatically - no setup needed!
- *         transaction {
+ *         // Telemetry works automatically!
+ *         transaction(database) {
  *             OrderTable.insert { ... }
  *             events.addEvent(OrderCreatedEvent(order.id))
  *         }

--- a/event-exposed/src/main/kotlin/com/turbomates/event/exposed/OpenTelemetryContextProvider.kt
+++ b/event-exposed/src/main/kotlin/com/turbomates/event/exposed/OpenTelemetryContextProvider.kt
@@ -12,9 +12,13 @@ package com.turbomates.event.exposed
  *
  * 2. Uncomment the code below
  *
- * 3. Initialize during application startup:
+ * 3. Use in your transactions:
  *    ```kotlin
- *    TelemetryContextHolder.provider = OpenTelemetryContextProvider()
+ *    transaction {
+ *        telemetryContextProvider = OpenTelemetryContextProvider()
+ *        // Your code here - trace/span will be captured automatically
+ *        events.addEvent(MyEvent())
+ *    }
  *    ```
  *
  * Example usage:
@@ -53,6 +57,22 @@ package com.turbomates.event.exposed
  *             )
  *         } else {
  *             TelemetryContext.EMPTY
+ *         }
+ *     }
+ * }
+ * ```
+ *
+ * Example with Spring Boot:
+ * ```kotlin
+ * @Service
+ * class OrderService {
+ *     private val telemetryProvider = OpenTelemetryContextProvider()
+ *
+ *     fun createOrder(order: Order) {
+ *         transaction {
+ *             telemetryContextProvider = telemetryProvider
+ *             OrderTable.insert { ... }
+ *             events.addEvent(OrderCreatedEvent(order.id))
  *         }
  *     }
  * }

--- a/event-exposed/src/main/kotlin/com/turbomates/event/exposed/OutboxInterceptor.kt
+++ b/event-exposed/src/main/kotlin/com/turbomates/event/exposed/OutboxInterceptor.kt
@@ -12,24 +12,29 @@ class OutboxInterceptor : GlobalStatementInterceptor {
 
     override fun beforeCommit(transaction: Transaction) {
         val events = transaction.events.raiseEvents().toList()
-        events.save()
+        transaction.save(events)
     }
 }
 
 val Transaction.events: EventStore by transactionScope { EventStore() }
-fun List<Event>.save() {
-    // Capture telemetry context once for all events in the batch
-    val telemetryContext = TelemetryContextHolder.provider.getCurrentContext()
 
-    val events = this.map { PublicEvent(it) }
-    EventsTable.batchInsert(events) { event ->
+/**
+ * Save events to outbox table with telemetry context.
+ * Uses the telemetry context provider associated with this transaction.
+ */
+fun Transaction.save(events: List<Event>) {
+    // Capture telemetry context once for all events in the batch
+    val telemetryContext = this.telemetryContextProvider.getCurrentContext()
+
+    val publicEvents = events.map { PublicEvent(it) }
+    EventsTable.batchInsert(publicEvents) { event ->
         this[EventsTable.id] = event.id
         this[EventsTable.event] = event.original
         this[EventsTable.createdAt] = event.createdAt
         this[EventsTable.traceId] = telemetryContext.traceId
         this[EventsTable.spanId] = telemetryContext.spanId
     }
-    val eventSourcingEvents = this.filterIsInstance<EventSourcingEvent>()
+    val eventSourcingEvents = events.filterIsInstance<EventSourcingEvent>()
     EventSourcingTable.batchInsert(eventSourcingEvents) { event ->
         this[EventSourcingTable.id] = UUID.randomUUID()
         this[EventSourcingTable.rootId] = event.rootId

--- a/event-exposed/src/main/kotlin/com/turbomates/event/exposed/OutboxPublisher.kt
+++ b/event-exposed/src/main/kotlin/com/turbomates/event/exposed/OutboxPublisher.kt
@@ -79,4 +79,6 @@ internal object EventsTable : UUIDTable("outbox_events") {
         jsonb("event", Json { ignoreUnknownKeys = true; encodeDefaults = true; prettyPrint = false }, EventSerializer)
     val publishedAt = datetime("published_at").nullable()
     val createdAt = datetime("created_at").clientDefault { LocalDateTime.now() }
+    val traceId = text("trace_id").nullable()
+    val spanId = text("span_id").nullable()
 }

--- a/event-exposed/src/main/kotlin/com/turbomates/event/exposed/TelemetryContext.kt
+++ b/event-exposed/src/main/kotlin/com/turbomates/event/exposed/TelemetryContext.kt
@@ -1,5 +1,8 @@
 package com.turbomates.event.exposed
 
+import org.jetbrains.exposed.sql.Transaction
+import org.jetbrains.exposed.sql.transactions.transactionScope
+
 /**
  * Represents telemetry context (trace and span information)
  * that should be propagated with events
@@ -34,10 +37,17 @@ object NoOpTelemetryContextProvider : TelemetryContextProvider {
 }
 
 /**
- * Global holder for telemetry context provider
- * Can be set during application initialization
+ * Extension property to access telemetry context provider for a transaction.
+ * Uses Exposed's transactionScope to store provider per transaction (thread-safe).
+ *
+ * Example usage:
+ * ```kotlin
+ * transaction {
+ *     telemetryContextProvider = OpenTelemetryContextProvider()
+ *     events.addEvent(MyEvent()) // Will use the provider set above
+ * }
+ * ```
  */
-object TelemetryContextHolder {
-    @Volatile
-    var provider: TelemetryContextProvider = NoOpTelemetryContextProvider
+var Transaction.telemetryContextProvider: TelemetryContextProvider by transactionScope {
+    NoOpTelemetryContextProvider
 }

--- a/event-exposed/src/main/kotlin/com/turbomates/event/exposed/TelemetryContext.kt
+++ b/event-exposed/src/main/kotlin/com/turbomates/event/exposed/TelemetryContext.kt
@@ -1,0 +1,43 @@
+package com.turbomates.event.exposed
+
+/**
+ * Represents telemetry context (trace and span information)
+ * that should be propagated with events
+ */
+data class TelemetryContext(
+    val traceId: String?,
+    val spanId: String?
+) {
+    companion object {
+        val EMPTY = TelemetryContext(null, null)
+    }
+}
+
+/**
+ * Interface for extracting current telemetry context from different
+ * telemetry implementations (OpenTelemetry, Micrometer, etc.)
+ */
+interface TelemetryContextProvider {
+    /**
+     * Extract current trace and span IDs from the active context
+     * @return TelemetryContext with trace/span IDs or EMPTY if no active trace
+     */
+    fun getCurrentContext(): TelemetryContext
+}
+
+/**
+ * Default implementation that returns empty context
+ * Used when telemetry is not configured
+ */
+object NoOpTelemetryContextProvider : TelemetryContextProvider {
+    override fun getCurrentContext(): TelemetryContext = TelemetryContext.EMPTY
+}
+
+/**
+ * Global holder for telemetry context provider
+ * Can be set during application initialization
+ */
+object TelemetryContextHolder {
+    @Volatile
+    var provider: TelemetryContextProvider = NoOpTelemetryContextProvider
+}

--- a/event-exposed/src/main/resources/migrations/add_telemetry_columns.sql
+++ b/event-exposed/src/main/resources/migrations/add_telemetry_columns.sql
@@ -1,0 +1,9 @@
+-- Migration to add telemetry context columns to outbox_events table
+-- This allows tracking trace and span IDs for distributed tracing
+
+ALTER TABLE outbox_events
+    ADD COLUMN IF NOT EXISTS trace_id text,
+    ADD COLUMN IF NOT EXISTS span_id text;
+
+-- Optional: Add index if you need to query by trace_id
+-- CREATE INDEX IF NOT EXISTS outbox_events_trace_id_idx ON outbox_events (trace_id);

--- a/event-exposed/src/main/resources/outbox_events_postgres_table.sql
+++ b/event-exposed/src/main/resources/outbox_events_postgres_table.sql
@@ -2,6 +2,8 @@
                 id uuid NOT NULL PRIMARY KEY,
                 event jsonb NOT NULL,
                 created_at timestamp with time zone DEFAULT timezone('UTC'::text, statement_timestamp()) NOT NULL,
-                published_at timestamp with time zone
+                published_at timestamp with time zone,
+                trace_id text,
+                span_id text
             );
 CREATE INDEX events_publisshed_idx ON outbox_events (published_at);

--- a/event-exposed/src/test/kotlin/com/turbomates/event/exposed/OutboxInterceptorTest.kt
+++ b/event-exposed/src/test/kotlin/com/turbomates/event/exposed/OutboxInterceptorTest.kt
@@ -39,6 +39,60 @@ class OutboxInterceptorTest {
             assertEquals(1, EventsTable.selectAll().count())
         }
     }
+
+    @Test
+    fun `should save telemetry context when provider is configured`() {
+        // Setup test telemetry provider
+        val testTraceId = "test-trace-id-12345"
+        val testSpanId = "test-span-id-67890"
+
+        TelemetryContextHolder.provider = object : TelemetryContextProvider {
+            override fun getCurrentContext() = TelemetryContext(testTraceId, testSpanId)
+        }
+
+        try {
+            transaction(database) {
+                Event::class.java.classLoader.getResourceAsStream("outbox_events_postgres_table.sql")?.apply {
+                    exec(String(readAllBytes()))
+                }
+            }
+
+            transaction(database) {
+                events.addEvent(TestEvent())
+            }
+
+            transaction(database) {
+                val savedEvent = EventsTable.selectAll().first()
+                assertEquals(testTraceId, savedEvent[EventsTable.traceId])
+                assertEquals(testSpanId, savedEvent[EventsTable.spanId])
+            }
+        } finally {
+            // Reset to default
+            TelemetryContextHolder.provider = NoOpTelemetryContextProvider
+        }
+    }
+
+    @Test
+    fun `should save null telemetry when no provider configured`() {
+        // Ensure default NoOp provider is used
+        TelemetryContextHolder.provider = NoOpTelemetryContextProvider
+
+        transaction(database) {
+            Event::class.java.classLoader.getResourceAsStream("outbox_events_postgres_table.sql")?.apply {
+                exec(String(readAllBytes()))
+            }
+        }
+
+        transaction(database) {
+            events.addEvent(TestEvent())
+        }
+
+        transaction(database) {
+            val savedEvent = EventsTable.selectAll().first()
+            assertEquals(null, savedEvent[EventsTable.traceId])
+            assertEquals(null, savedEvent[EventsTable.spanId])
+        }
+    }
     @Serializable
     private class TestEvent : Event() {
         override val key get() = TestEvent

--- a/event-exposed/src/test/kotlin/com/turbomates/event/exposed/OutboxInterceptorTest.kt
+++ b/event-exposed/src/test/kotlin/com/turbomates/event/exposed/OutboxInterceptorTest.kt
@@ -92,31 +92,26 @@ class OutboxInterceptorTest {
         val testTraceId = "default-trace-id"
         val testSpanId = "default-span-id"
 
-        // Set default provider
-        TelemetryConfig.setDefaultProvider(object : TelemetryContextProvider {
+        // Set provider for this database instance
+        database.telemetryProvider = object : TelemetryContextProvider {
             override fun getCurrentContext() = TelemetryContext(testTraceId, testSpanId)
-        })
+        }
 
-        try {
-            transaction(database) {
-                Event::class.java.classLoader.getResourceAsStream("outbox_events_postgres_table.sql")?.apply {
-                    exec(String(readAllBytes()))
-                }
+        transaction(database) {
+            Event::class.java.classLoader.getResourceAsStream("outbox_events_postgres_table.sql")?.apply {
+                exec(String(readAllBytes()))
             }
+        }
 
-            transaction(database) {
-                // No need to set provider - uses default automatically
-                events.addEvent(TestEvent())
-            }
+        transaction(database) {
+            // No need to set provider - uses database's provider automatically
+            events.addEvent(TestEvent())
+        }
 
-            transaction(database) {
-                val savedEvent = EventsTable.selectAll().first()
-                assertEquals(testTraceId, savedEvent[EventsTable.traceId])
-                assertEquals(testSpanId, savedEvent[EventsTable.spanId])
-            }
-        } finally {
-            // Reset to NoOp for other tests
-            TelemetryConfig.setDefaultProvider(NoOpTelemetryContextProvider)
+        transaction(database) {
+            val savedEvent = EventsTable.selectAll().first()
+            assertEquals(testTraceId, savedEvent[EventsTable.traceId])
+            assertEquals(testSpanId, savedEvent[EventsTable.spanId])
         }
     }
 
@@ -125,39 +120,35 @@ class OutboxInterceptorTest {
         val defaultTraceId = "default-trace"
         val overrideTraceId = "override-trace"
 
-        // Set default provider
-        TelemetryConfig.setDefaultProvider(object : TelemetryContextProvider {
+        // Set provider for database
+        database.telemetryProvider = object : TelemetryContextProvider {
             override fun getCurrentContext() = TelemetryContext(defaultTraceId, "default-span")
-        })
+        }
 
-        try {
-            transaction(database) {
-                Event::class.java.classLoader.getResourceAsStream("outbox_events_postgres_table.sql")?.apply {
-                    exec(String(readAllBytes()))
-                }
+        transaction(database) {
+            Event::class.java.classLoader.getResourceAsStream("outbox_events_postgres_table.sql")?.apply {
+                exec(String(readAllBytes()))
             }
+        }
 
-            // Transaction 1: uses default provider
-            transaction(database) {
-                events.addEvent(TestEvent())
-            }
+        // Transaction 1: uses database's provider
+        transaction(database) {
+            events.addEvent(TestEvent())
+        }
 
-            // Transaction 2: overrides with custom provider
-            transaction(database) {
-                telemetryContextProvider = object : TelemetryContextProvider {
-                    override fun getCurrentContext() = TelemetryContext(overrideTraceId, "override-span")
-                }
-                events.addEvent(TestEvent())
+        // Transaction 2: overrides with custom provider
+        transaction(database) {
+            telemetryContextProvider = object : TelemetryContextProvider {
+                override fun getCurrentContext() = TelemetryContext(overrideTraceId, "override-span")
             }
+            events.addEvent(TestEvent())
+        }
 
-            transaction(database) {
-                val events = EventsTable.selectAll().toList()
-                assertEquals(2, events.size)
-                assertEquals(defaultTraceId, events[0][EventsTable.traceId])
-                assertEquals(overrideTraceId, events[1][EventsTable.traceId])
-            }
-        } finally {
-            TelemetryConfig.setDefaultProvider(NoOpTelemetryContextProvider)
+        transaction(database) {
+            val events = EventsTable.selectAll().toList()
+            assertEquals(2, events.size)
+            assertEquals(defaultTraceId, events[0][EventsTable.traceId])
+            assertEquals(overrideTraceId, events[1][EventsTable.traceId])
         }
     }
     @Serializable


### PR DESCRIPTION
This pull request introduces telemetry context support for the outbox event system, enabling distributed tracing by capturing and persisting trace and span IDs with each event. The changes are fully backward compatible and provide a flexible, thread-safe mechanism to integrate with OpenTelemetry, Micrometer, or any custom telemetry provider. Telemetry context can be configured per database or overridden per transaction. The database schema and event persistence logic are updated to support the new fields, and comprehensive documentation and tests are included.

**Telemetry context integration:**

- Added `TelemetryContext` data class and `TelemetryContextProvider` interface, allowing the extraction and propagation of trace and span IDs from various telemetry systems. A default no-op provider ensures backward compatibility when telemetry is not configured. (`event-exposed/src/main/kotlin/com/turbomates/event/exposed/TelemetryContext.kt`)
- Provided extension properties for associating a telemetry provider with a `Database` instance and for accessing or overriding the provider within a `Transaction`, ensuring thread safety and per-transaction isolation. (`event-exposed/src/main/kotlin/com/turbomates/event/exposed/TelemetryContext.kt`)

**Database schema and persistence changes:**

- Updated the `outbox_events` table to include nullable `trace_id` and `span_id` columns for storing telemetry context. Migration scripts and schema files are provided for both Postgres and general migrations. (`event-exposed/src/main/resources/migrations/add_telemetry_columns.sql`, `event-exposed/src/main/resources/outbox_events_postgres_table.sql`, `event-exposed/src/main/kotlin/com/turbomates/event/exposed/OutboxPublisher.kt`) [[1]](diffhunk://#diff-7f155158f8f142d0b153aa1e50fb46ede7d7fd46d58f5f7a1a66f14f107f6528R1-R9) [[2]](diffhunk://#diff-32c03374ce63e75eed67d941b9aa23c8e60623a098416801c9aaa7842e7bd4a9L5-R7) [[3]](diffhunk://#diff-89debe8ee9f661fc6729f66c815f1be931064150d08bed489a63e97d76ae8fedR82-R83)
- Modified event saving logic to capture the telemetry context once per transaction and persist trace and span IDs with each event. (`event-exposed/src/main/kotlin/com/turbomates/event/exposed/OutboxInterceptor.kt`)

**Documentation and examples:**

- Added comprehensive documentation (`TELEMETRY.md`) detailing the architecture, configuration, usage examples for OpenTelemetry and Micrometer, integration with frameworks (Spring Boot, Ktor), migration instructions, and testing strategies. (`event-exposed/TELEMETRY.md`)
- Included a reference implementation for `OpenTelemetryContextProvider` with usage instructions and examples for both OpenTelemetry and Micrometer. (`event-exposed/src/main/kotlin/com/turbomates/event/exposed/OpenTelemetryContextProvider.kt`)

**Testing:**

- Added extensive tests to verify correct persistence of telemetry context, default and overridden provider behavior, and isolation between transactions. (`event-exposed/src/test/kotlin/com/turbomates/event/exposed/OutboxInterceptorTest.kt`)